### PR TITLE
Expose stream resolution to libcamera.conf

### DIFF
--- a/configs/libcamera.conf
+++ b/configs/libcamera.conf
@@ -9,6 +9,9 @@ PORT=8080
 WIDTH=1920
 HEIGHT=1080
 
+# The height to use for the direct stream. Defaults to 480.
+STREAM_HEIGHT=480
+
 # The height to use for the video stream. Defaults to 720.
 VIDEO_HEIGHT=720
 

--- a/systemd/camera-streamer-libcamera.service
+++ b/systemd/camera-streamer-libcamera.service
@@ -14,6 +14,7 @@ ExecStart=/bin/sh -c "exec /usr/bin/camera-streamer \
   --camera-path=$(/usr/bin/libcamera-hello --list-cameras | grep -o '/base/soc/[^)]*' | head -n1) \
   --camera-format=YUYV \
   --camera-width=${WIDTH} --camera-height=${HEIGHT} \
+  --camera-stream.height=${STREAM_HEIGHT} \
   --camera-video.height=${VIDEO_HEIGHT} \
   --camera-snapshot.height=${SNAPSHOT_HEIGHT} \
   --camera-fps=${FRAMERATE} \


### PR DESCRIPTION
I've added an additional setting to libcamera.conf so that the stream resolution can be set differently than the video resolution.

This way I can set a low resolution on `/webcam/?action=stream`, which doesn't need to be large when using in controls tab.
When I want to capture a higher resolution stream, in can use `/webcam/video.*`.